### PR TITLE
Added AWS S3 Express One Zone Benchmarking

### DIFF
--- a/experimentResults/s3-express-result.txt
+++ b/experimentResults/s3-express-result.txt
@@ -1,0 +1,108 @@
+(.venv) [ec2-user@ip-10-0-39-49 test-1]$ python s3-express-sdk.py 
+Creating Express One Zone directory bucket: express-bucket-1743443012380814474--use1-az6--x-s3
+Starting write operations for varying object sizes...
+
+Writing 50 objects of size 1024 bytes
+
+Write (Size: 1024 bytes) Metrics:
+Min Latency: 7.52 ms
+Average Latency: 10.15 ms
+P90 Latency: 10.37 ms
+P95 Latency: 11.15 ms
+P99 Latency: 32.58 ms
+Throughput: 98.54 ops/sec
+Throughput: 0.0001 GB/sec
+
+Writing 50 objects of size 1048576 bytes
+
+Write (Size: 1048576 bytes) Metrics:
+Min Latency: 10.86 ms
+Average Latency: 13.60 ms
+P90 Latency: 15.65 ms
+P95 Latency: 15.77 ms
+P99 Latency: 16.06 ms
+Throughput: 73.50 ops/sec
+Throughput: 0.0718 GB/sec
+
+Writing 50 objects of size 10485760 bytes
+
+Write (Size: 10485760 bytes) Metrics:
+Min Latency: 90.05 ms
+Average Latency: 94.98 ms
+P90 Latency: 98.27 ms
+P95 Latency: 98.78 ms
+P99 Latency: 99.23 ms
+Throughput: 10.53 ops/sec
+Throughput: 0.1028 GB/sec
+
+Starting read operations for varying object sizes...
+
+Reading 50 objects of size 1024 bytes
+
+Read (Size: 1024 bytes) Metrics:
+Min Latency: 5.45 ms
+Average Latency: 6.12 ms
+P90 Latency: 6.80 ms
+P95 Latency: 6.94 ms
+P99 Latency: 7.05 ms
+Throughput: 163.38 ops/sec
+Throughput: 0.0002 GB/sec
+
+Reading 50 objects of size 1048576 bytes
+
+Read (Size: 1048576 bytes) Metrics:
+Min Latency: 8.97 ms
+Average Latency: 9.70 ms
+P90 Latency: 10.28 ms
+P95 Latency: 10.48 ms
+P99 Latency: 10.76 ms
+Throughput: 103.12 ops/sec
+Throughput: 0.1007 GB/sec
+
+Reading 50 objects of size 10485760 bytes
+
+Read (Size: 10485760 bytes) Metrics:
+Min Latency: 75.79 ms
+Average Latency: 78.95 ms
+P90 Latency: 81.48 ms
+P95 Latency: 81.73 ms
+P99 Latency: 81.87 ms
+Throughput: 12.67 ops/sec
+Throughput: 0.1237 GB/sec
+
+Starting delete operations...
+
+Deleting 50 objects of size 1024 bytes
+
+Delete (Size: 1024 bytes) Metrics:
+Min Latency: 4.78 ms
+Average Latency: 7.06 ms
+P90 Latency: 8.66 ms
+P95 Latency: 8.91 ms
+P99 Latency: 9.09 ms
+Throughput: 141.69 ops/sec
+Throughput: 0.0001 GB/sec
+
+Deleting 50 objects of size 1048576 bytes
+
+Delete (Size: 1048576 bytes) Metrics:
+Min Latency: 4.73 ms
+Average Latency: 7.15 ms
+P90 Latency: 8.87 ms
+P95 Latency: 9.26 ms
+P99 Latency: 9.47 ms
+Throughput: 139.81 ops/sec
+Throughput: 0.1365 GB/sec
+
+Deleting 50 objects of size 10485760 bytes
+
+Delete (Size: 10485760 bytes) Metrics:
+Min Latency: 4.56 ms
+Average Latency: 7.03 ms
+P90 Latency: 8.24 ms
+P95 Latency: 8.70 ms
+P99 Latency: 9.20 ms
+Throughput: 142.28 ops/sec
+Throughput: 1.3895 GB/sec
+
+Cleaning up bucket: express-bucket-1743443012380814474--use1-az6--x-s3

--- a/s3-client-test/golang/test-1/express/s3-express-sdk.go
+++ b/s3-client-test/golang/test-1/express/s3-express-sdk.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"log"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// percentile calculates the p-th percentile of a sorted slice of float64 values.
+func percentile(values []float64, p float64) float64 {
+	if len(values) == 0 {
+		return 0.0
+	}
+	k := float64(len(values)-1) * p
+	f := int(k)
+	c := f + 1
+	if c >= len(values) {
+		c = len(values) - 1
+	}
+	d0 := values[f] * (float64(c) - k)
+	d1 := values[c] * (k - float64(f))
+	return d0 + d1
+}
+
+// calculateMetrics calculates and prints performance metrics for a set of latencies.
+func calculateMetrics(latencies []time.Duration, operation string, dataSize int64) {
+	if len(latencies) == 0 {
+		fmt.Printf("\nNo latencies recorded for %s\n", operation)
+		return
+	}
+
+	// Convert durations to float64 seconds for calculations
+	floatLatencies := make([]float64, len(latencies))
+	var totalLatency time.Duration
+	for i, lat := range latencies {
+		floatLatencies[i] = lat.Seconds()
+		totalLatency += lat
+	}
+
+	// Sort latencies for percentile calculations
+	sort.Float64s(floatLatencies)
+
+	// Calculate basic statistics
+	minLatency := floatLatencies[0]
+	avgLatency := totalLatency.Seconds() / float64(len(latencies))
+
+	// Calculate throughput in ops/sec
+	opsPerSec := float64(len(latencies)) / totalLatency.Seconds()
+
+	// Calculate throughput in GB/sec if dataSize is provided
+	var gbPerSec float64
+	if dataSize > 0 {
+		totalBytes := dataSize * int64(len(latencies))
+		gbPerSec = (float64(totalBytes) / totalLatency.Seconds()) / (1024 * 1024 * 1024)
+	}
+
+	// Calculate percentiles
+	p90 := percentile(floatLatencies, 0.90)
+	p95 := percentile(floatLatencies, 0.95)
+	p99 := percentile(floatLatencies, 0.99)
+
+	// Convert latencies from seconds to milliseconds for printing
+	minMs := minLatency * 1000
+	avgMs := avgLatency * 1000
+	p90Ms := p90 * 1000
+	p95Ms := p95 * 1000
+	p99Ms := p99 * 1000
+
+	fmt.Printf("\n%s Metrics:\n", operation)
+	fmt.Printf("Min Latency: %.2f ms\n", minMs)
+	fmt.Printf("Average Latency: %.2f ms\n", avgMs)
+	fmt.Printf("P90 Latency: %.2f ms\n", p90Ms)
+	fmt.Printf("P95 Latency: %.2f ms\n", p95Ms)
+	fmt.Printf("P99 Latency: %.2f ms\n", p99Ms)
+	fmt.Printf("Throughput: %.2f ops/sec\n", opsPerSec)
+	if dataSize > 0 {
+		fmt.Printf("Throughput: %.4f GB/sec\n", gbPerSec)
+	}
+}
+
+func main() {
+	region := "us-east-1"
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
+	if err != nil {
+		log.Fatalf("Unable to load SDK config, %v", err)
+	}
+
+	s3Client := s3.NewFromConfig(cfg)
+	ctx := context.TODO()
+
+	// Create a unique bucket name for Express One Zone
+	baseName := "go-express-bucket-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	zoneID := "use1-az6" // Zone ID for us-east-1c
+	bucketName := fmt.Sprintf("%s--%s--x-s3", baseName, zoneID)
+
+	var bucketCreated bool
+
+	// Ensure bucket cleanup happens even on errors after creation
+	defer func() {
+		if bucketCreated {
+			cleanupBucket(ctx, s3Client, bucketName)
+		}
+	}()
+
+	// Create Express One Zone directory bucket
+	fmt.Printf("Creating Express One Zone directory bucket: %s\n", bucketName)
+	_, err = s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{
+			Bucket: &types.BucketInfo{
+				Type:           types.BucketTypeDirectory,
+				DataRedundancy: types.DataRedundancySingleAvailabilityZone,
+			},
+			Location: &types.LocationInfo{
+				Name: aws.String(zoneID),
+				Type: types.LocationTypeAvailabilityZone,
+			},
+		},
+	})
+	if err != nil {
+		log.Fatalf("Failed to create bucket %s: %v", bucketName, err)
+	}
+	bucketCreated = true
+	fmt.Printf("Successfully created bucket %s\n", bucketName)
+
+	// Allow some time for bucket creation to propagate (optional but can help prevent immediate errors)
+	// time.Sleep(5 * time.Second)
+
+	// Define test object sizes
+	objectSizes := []int64{1024, 1024 * 1024, 10 * 1024 * 1024} // 1KB, 1MB, 10MB
+	numObjects := 50
+
+	// --- Step 1: Write objects ---
+	fmt.Println("\nStarting write operations for varying object sizes...")
+	for _, size := range objectSizes {
+		fmt.Printf("\nWriting %d objects of size %d bytes\n", numObjects, size)
+		writeLatencies := make([]time.Duration, 0, numObjects)
+		data := make([]byte, size)
+
+		for i := 0; i < numObjects; i++ {
+			key := fmt.Sprintf("key_%d_size_%d", i, size)
+			_, err := rand.Read(data) // Generate random data for each object
+			if err != nil {
+				log.Printf("Failed to generate random data for %s: %v", key, err)
+				continue
+			}
+
+			start := time.Now()
+			_, err = s3Client.PutObject(ctx, &s3.PutObjectInput{
+				Bucket: aws.String(bucketName),
+				Key:    aws.String(key),
+				Body:   bytes.NewReader(data), // Corrected Body type
+			})
+			latency := time.Since(start)
+
+			if err != nil {
+				log.Printf("Failed to put object %s: %v", key, err)
+			} else {
+				writeLatencies = append(writeLatencies, latency)
+			}
+		}
+		calculateMetrics(writeLatencies, fmt.Sprintf("Write (Size: %d bytes)", size), size)
+	}
+
+	// --- Step 2: Read objects ---
+	fmt.Println("\nStarting read operations for varying object sizes...")
+	for _, size := range objectSizes {
+		fmt.Printf("\nReading %d objects of size %d bytes\n", numObjects, size)
+		readLatencies := make([]time.Duration, 0, numObjects)
+
+		for i := 0; i < numObjects; i++ {
+			key := fmt.Sprintf("key_%d_size_%d", i, size)
+
+			start := time.Now() // Start timer before GetObject
+			resp, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
+				Bucket: aws.String(bucketName),
+				Key:    aws.String(key),
+			})
+
+			if err != nil {
+				log.Printf("Failed to get object %s: %v", key, err)
+			} else {
+				// Read and close the body to complete the operation
+				_, readErr := io.ReadAll(resp.Body)
+				closeErr := resp.Body.Close()
+				latency := time.Since(start) // Measure latency AFTER reading and closing body
+
+				if readErr != nil {
+					log.Printf("Failed to read body for object %s: %v", key, readErr)
+					// Optionally skip appending latency if read fails
+					continue
+				}
+				if closeErr != nil {
+					log.Printf("Failed to close body for object %s: %v", key, closeErr)
+					// Optionally skip appending latency if close fails
+					continue
+				}
+				readLatencies = append(readLatencies, latency) // Append latency including read time
+			}
+		}
+		calculateMetrics(readLatencies, fmt.Sprintf("Read (Size: %d bytes)", size), size)
+	}
+
+	// --- Step 3: Delete objects ---
+	// Note: Cleanup function called via defer handles deletion,
+	// but we can measure individual deletes here if needed.
+	fmt.Println("\nStarting delete operations...")
+	for _, size := range objectSizes {
+		fmt.Printf("\nDeleting %d objects of size %d bytes\n", numObjects, size)
+		deleteLatencies := make([]time.Duration, 0, numObjects)
+
+		for i := 0; i < numObjects; i++ {
+			key := fmt.Sprintf("key_%d_size_%d", i, size)
+
+			start := time.Now()
+			_, err := s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+				Bucket: aws.String(bucketName),
+				Key:    aws.String(key),
+			})
+			latency := time.Since(start)
+
+			if err != nil {
+				log.Printf("Failed to delete object %s: %v", key, err)
+			} else {
+				deleteLatencies = append(deleteLatencies, latency)
+			}
+		}
+		calculateMetrics(deleteLatencies, fmt.Sprintf("Delete (Size: %d bytes)", size), 0) // dataSize = 0 for delete
+	}
+}
+
+// cleanupBucket deletes all objects in the bucket and then deletes the bucket itself.
+func cleanupBucket(ctx context.Context, s3Client *s3.Client, bucketName string) {
+	fmt.Printf("\nCleaning up bucket: %s\n", bucketName)
+
+	// List and delete all objects
+	var objectsToDelete []types.ObjectIdentifier
+	paginator := s3.NewListObjectsV2Paginator(s3Client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucketName),
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			log.Printf("Failed to list objects for cleanup in %s: %v", bucketName, err)
+			// Proceed to try deleting the bucket anyway, might fail if not empty
+			break
+		}
+		for _, obj := range page.Contents {
+			objectsToDelete = append(objectsToDelete, types.ObjectIdentifier{Key: obj.Key})
+		}
+	}
+
+	// Batch delete objects (up to 1000 per request)
+	if len(objectsToDelete) > 0 {
+		// S3 batch delete takes max 1000 keys
+		chunkSize := 1000
+		for i := 0; i < len(objectsToDelete); i += chunkSize {
+			end := i + chunkSize
+			if end > len(objectsToDelete) {
+				end = len(objectsToDelete)
+			}
+			chunk := objectsToDelete[i:end]
+
+			fmt.Printf("Deleting %d objects...\n", len(chunk))
+			_, err := s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+				Bucket: aws.String(bucketName),
+				Delete: &types.Delete{Objects: chunk},
+			})
+			if err != nil {
+				log.Printf("Failed to delete object chunk in %s: %v", bucketName, err)
+				// Continue trying to delete other chunks/bucket
+			}
+		}
+	} else {
+		fmt.Println("No objects found to delete.")
+	}
+
+	// Delete bucket
+	fmt.Println("Deleting bucket...")
+	_, err := s3Client.DeleteBucket(ctx, &s3.DeleteBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		log.Printf("Failed to delete bucket %s: %v", bucketName, err)
+	} else {
+		fmt.Println("Successfully deleted bucket.")
+	}
+}

--- a/s3-client-test/python/test-1/express/s3-express-sdk.py
+++ b/s3-client-test/python/test-1/express/s3-express-sdk.py
@@ -1,0 +1,175 @@
+import os
+import time
+import random
+import boto3
+from botocore.exceptions import ClientError
+
+def percentile(values, perc):
+    """Calculate percentile of a sorted list of values."""
+    k = (len(values) - 1) * perc
+    f = int(k)
+    c = int(k) + 1 if k < len(values) - 1 else int(k)
+    d0 = values[f] * (c - k)
+    d1 = values[c] * (k - f)
+    return d0 + d1
+
+def calculate_metrics(latencies, operation, data_size=0):
+    """Calculate and print metrics for operations."""
+    # Sort latencies for percentile calculations
+    sorted_latencies = sorted(latencies)
+    
+    # Calculate basic statistics
+    min_latency = sorted_latencies[0]
+    avg_latency = sum(latencies) / len(latencies)
+    
+    # Calculate throughput in ops/sec
+    ops_per_sec = len(latencies) / sum(latencies)
+    
+    # Calculate throughput in GB/sec if data_size is provided
+    if data_size > 0:
+        total_bytes = data_size * len(latencies)
+        gb_per_sec = (total_bytes / sum(latencies)) / (1024 * 1024 * 1024)
+    
+    # Calculate percentiles
+    p90 = percentile(sorted_latencies, 0.90)
+    p95 = percentile(sorted_latencies, 0.95)
+    p99 = percentile(sorted_latencies, 0.99)
+    
+    # Convert latencies from seconds to milliseconds
+    min_ms = min_latency * 1000
+    avg_ms = avg_latency * 1000
+    p90_ms = p90 * 1000
+    p95_ms = p95 * 1000
+    p99_ms = p99 * 1000
+    
+    print(f"\n{operation} Metrics:")
+    print(f"Min Latency: {min_ms:.2f} ms")
+    print(f"Average Latency: {avg_ms:.2f} ms")
+    print(f"P90 Latency: {p90_ms:.2f} ms")
+    print(f"P95 Latency: {p95_ms:.2f} ms")
+    print(f"P99 Latency: {p99_ms:.2f} ms")
+    print(f"Throughput: {ops_per_sec:.2f} ops/sec")
+    if data_size > 0:
+        print(f"Throughput: {gb_per_sec:.4f} GB/sec")
+
+def main():
+    # Initialize S3 client
+    s3_client = boto3.client('s3', region_name='us-east-1')
+    
+    try:
+        # Create a unique bucket name for Express One Zone
+        # Directory bucket names must follow the format: base-name--zone-id--x-s3
+        # For us-east-1c, the zone ID is use1-az6
+        base_name = f"express-bucket-{int(time.time_ns())}"
+        zone_id = "use1-az6"  # Zone ID for us-east-1c
+        bucket = f"{base_name}--{zone_id}--x-s3"
+        
+        # Create Express One Zone directory bucket
+        print(f"Creating Express One Zone directory bucket: {bucket}")
+        s3_client.create_bucket(
+            Bucket=bucket,
+            CreateBucketConfiguration={
+                'Bucket': {
+                    'Type': 'Directory',
+                    'DataRedundancy': 'SingleAvailabilityZone'
+                },
+                'Location': {
+                    'Type': 'AvailabilityZone',
+                    'Name': zone_id
+                }
+            }
+        )
+        
+        try:
+            # Define test object sizes
+            object_sizes = [1024, 1024 * 1024, 10 * 1024 * 1024]  # 1KB, 1MB, 10MB
+            num_objects = 50
+
+            # Step 1: Write objects of varying sizes
+            print("Starting write operations for varying object sizes...")
+            for size in object_sizes:
+                print(f"\nWriting {num_objects} objects of size {size} bytes")
+                write_latencies = []
+                
+                for i in range(num_objects):
+                    key = f"key_{i}_size_{size}"
+                    data = random.randbytes(size)
+                    
+                    start = time.time()
+                    s3_client.put_object(
+                        Bucket=bucket,
+                        Key=key,
+                        Body=data
+                    )
+                    write_latencies.append(time.time() - start)
+                    
+                calculate_metrics(write_latencies, f"Write (Size: {size} bytes)", size)
+
+            # Step 2: Read objects
+            print("\nStarting read operations for varying object sizes...")
+            for size in object_sizes:
+                print(f"\nReading {num_objects} objects of size {size} bytes")
+                read_latencies = []
+                
+                for i in range(num_objects):
+                    key = f"key_{i}_size_{size}"
+                    
+                    start = time.time()
+                    try:
+                        response = s3_client.get_object(
+                            Bucket=bucket,
+                            Key=key
+                        )
+                        # Read all data to fully complete the operation
+                        response['Body'].read()
+                    except ClientError as e:
+                        print(f"Failed to get object {key}: {e}")
+                        
+                    read_latencies.append(time.time() - start)
+                    
+                calculate_metrics(read_latencies, f"Read (Size: {size} bytes)", size)
+
+            # Step 3: Delete objects
+            print("\nStarting delete operations...")
+            for size in object_sizes:
+                print(f"\nDeleting {num_objects} objects of size {size} bytes")
+                delete_latencies = []
+                
+                for i in range(num_objects):
+                    key = f"key_{i}_size_{size}"
+                    
+                    start = time.time()
+                    try:
+                        s3_client.delete_object(
+                            Bucket=bucket,
+                            Key=key
+                        )
+                    except ClientError as e:
+                        print(f"Failed to delete object {key}: {e}")
+                        
+                    delete_latencies.append(time.time() - start)
+                    
+                calculate_metrics(delete_latencies, f"Delete (Size: {size} bytes)", size)
+
+        finally:
+            # Clean up - delete any remaining objects and bucket
+            print(f"\nCleaning up bucket: {bucket}")
+            try:
+                # List and delete all objects
+                response = s3_client.list_objects_v2(Bucket=bucket)
+                if 'Contents' in response:
+                    for obj in response['Contents']:
+                        s3_client.delete_object(
+                            Bucket=bucket,
+                            Key=obj['Key']
+                        )
+                # Delete bucket
+                s3_client.delete_bucket(Bucket=bucket)
+            except ClientError as e:
+                print(f"Error during cleanup: {e}")
+            
+    except ClientError as e:
+        print(f"S3 operation error: {e}")
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
This pull request includes significant changes to add performance testing scripts for S3 Express One Zone storage in both Python and Go. The changes involve creating new scripts to measure and report latency and throughput for various S3 operations (write, read, and delete) on objects of different sizes.

Performance testing scripts:

* [`s3-client-test/golang/test-1/express/s3-express-sdk.go`](diffhunk://#diff-54f92b050d6967988d0cb9c260aab732987a191a2e8e1b2a11a7265e7eb67b31R1-R300): Added a Go script to create an S3 bucket, perform write, read, and delete operations on objects of varying sizes, and calculate performance metrics such as latency and throughput.
* [`s3-client-test/python/test-1/express/s3-express-sdk.py`](diffhunk://#diff-5fa67f09f76cab6837d142d880206a85f933eaa139f8d4351cd94c46e48038a1R1-R175): Added a Python script to perform similar operations as the Go script, including creating an S3 bucket, conducting write, read, and delete operations on objects of different sizes, and calculating performance metrics.

Experiment results:

* [`experimentResults/s3-express-result.txt`](diffhunk://#diff-424711c67cbef73f8d92b1eb4cea1274d237c568425bb3e960772a5925fd6d47R1-R108): Added a text file containing the results of the performance tests, including metrics for write, read, and delete operations on objects of different sizes.